### PR TITLE
Fix unbound variables

### DIFF
--- a/src/runner.sh
+++ b/src/runner.sh
@@ -213,6 +213,7 @@ runner_bootstrap() {
   ## Clear a trap we set up earlier
   trap - EXIT
   ## Parse arguments
+  local runner_tasks=()
   for arg in "${runner_args[@]}"; do
     if [[ ${arg} == -* ]]; then
       runner_flags+=("${arg}")

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -53,7 +53,7 @@ alias runner_time="runner_date +%s%3N"
 ## Returns a human readable duration in ms
 runner_pretty_ms() {
   local -i ms="${1}"
-  local result
+  local result=""
   ## If zero or nothing
   if [[ -z ${ms} || ${ms} -lt 1 ]]; then
     echo "0 ms"


### PR DESCRIPTION
This PR fixes two "unbound variable" errors (found in [vendored](https://github.com/stylemistake/runner#simple-vendored) usage).

In every Bash script I use the following commands to make a bugfixing easier and my ```runnerfile.sh``` is not an exception:

    set -o errexit
    set -o errtrace
    set -o nounset
    set -o pipefail

When use this on top of my ```runnerfile.sh``` I was getting "unbound variable" error on two places.

1. ```runner_bootstrap``` (runner_tasks) when ```runnerfile.sh``` is called without any parameter
2. ```runner_pretty_ms``` (result) when the task time is longer than 60 seconds

```runnerfile.sh``` for test:

    #!/usr/bin/env bash
    cd "$(dirname "$0")" || exit
    source ./runner.sh

    set -o xtrace
    set -o errexit
    set -o errtrace
    set -o nounset
    set -o pipefail

    task_default() {
        sleep 65
    }
