### PR TITLE
Fix Bash4 behavior with set -o nounset

### DIFF
--- a/src/runner.sh
+++ b/src/runner.sh
@@ -18,8 +18,8 @@ declare -a runner_args=("${@}")
 ## All flags are then passed on to tasks.
 ## E.g. --production
 ## NOTE: The actual splitting is done in runner_bootstrap.
-declare -a runner_flags
-declare -a runner_tasks
+declare -a runner_flags=()
+declare -a runner_tasks=()
 
 ## Logs a message with a timestamp
 runner_log() {
@@ -164,7 +164,7 @@ runner_run_task() {
   local task_color="$(runner_colorize cyan "${1}")"
   runner_log "Starting '${task_color}'..."
   local -i time_start="$(runner_time)"
-  "task_${1}" "${runner_flags[@]}"
+  "task_${1}" "${runner_flags[@]+"${runner_flags[@]}"}"
   local exit_code=${?}
   local -i time_end="$(runner_time)"
   local time_diff="$(runner_pretty_ms $((time_end - time_start)))"
@@ -213,8 +213,7 @@ runner_bootstrap() {
   ## Clear a trap we set up earlier
   trap - EXIT
   ## Parse arguments
-  local runner_tasks=()
-  for arg in "${runner_args[@]}"; do
+  for arg in "${runner_args[@]+"${runner_args[@]}"}"; do
     if [[ ${arg} == -* ]]; then
       runner_flags+=("${arg}")
     else


### PR DESCRIPTION
This PR fixes inconsistent behavior between Bash 4.4 and lower versions while using `set -o nounset`.

I believe `set -o nounset` is very helpful for more complex runnerfiles and this PR should address two things:

1. Unbound variables in `runner_bootstrap` and `runner_run_task`
2. Empty task name in `runner_bootstrap` when called without parameters (i.e. default task should be invoked)

Example `runnerfile.sh`:

    #!/usr/bin/env bash
    cd "$(dirname "$0")" || exit
    source src/runner.sh

    set -o xtrace
    set -o errtrace
    set -o nounset
    set -o pipefail

    task_default() {
        runner_log "I'm default task: ${*}"
    }

    task_example() {
        runner_log "I'm example task: ${*}"
    }

Using Bash version prior to 4.4 the `runnerfile.sh` was failing with either "_unbound variable_" or "_Task '' is not defined!_".

Tested in Bash 4.0, 4.1, 4.2, 4.3, 4.4 and 5.0 from https://hub.docker.com/_/bash.

Please consider merging this because Bash versions < 4.4 are still pretty common.
