### PR TITLE
Remove LF in runner_colorize

### DIFF
--- a/src/runner.sh
+++ b/src/runner.sh
@@ -109,7 +109,8 @@ if ((BASH_VERSINFO[0] >= 4)); then
   )
 
   runner_colorize() {
-    echo "${runner_colors[$1]}${*:2}${runner_colors[reset]}"
+    message=("${@:2}")
+    (IFS=" "; echo "${runner_colors[$1]}${message[*]}${runner_colors[reset]}")
   }
 else
   runner_colorize() {

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -109,8 +109,11 @@ if ((BASH_VERSINFO[0] >= 4)); then
   )
 
   runner_colorize() {
-    message=("${@:2}")
-    (IFS=" "; echo "${runner_colors[$1]}${message[*]}${runner_colors[reset]}")
+    local message=("${@:2}")
+    local ifs="${IFS}"
+    IFS=" "
+    echo "${runner_colors[$1]}${message[*]}${runner_colors[reset]}"
+    IFS="${ifs}"
   }
 else
   runner_colorize() {


### PR DESCRIPTION
# Remove LF from `runner_colorize` output

## Reasoning
When using `runner_cmd` with command including a lot of arguments (like Helm) there is LF after each argument. It makes an output in console cluttered and hard to read.
```
[19:49:15.766] helm
upgrade
--install
--atomic
--namespace
test
--values
test.yaml
--set
image=test:local
this
chart
```
vs
```
[19:47:52.324] helm upgrade --install --atomic --namespace test --values test.yaml --set image=test:local this chart
```

## Test
**Test task**
```
task_test_colorize() {
    runner_colorize "green" "this is a message"
    runner_colorize "yellow" "this" "is" "a" "message"
    runner_run helm version
}
```
**Original output**
```
[19:37:37.807] Starting 'test_colorize'...
this is a message
this
is
a
message
[19:37:38.010] helm
version
version.BuildInfo{Version:"v3.13.0", GitCommit:"825e86f6a7a38cef1112bfa606e4127a706749b1", GitTreeState:"clean", GoVersion:"go1.20.8"}
[19:37:38.393] Finished 'test_colorize'
after 373 ms
```
**Output after change**
```
[19:38:24.656] Starting 'test_colorize'...
this is a message
this is a message
[19:38:24.950] helm version
version.BuildInfo{Version:"v3.13.0", GitCommit:"825e86f6a7a38cef1112bfa606e4127a706749b1", GitTreeState:"clean", GoVersion:"go1.20.8"}
[19:38:25.376] Finished 'test_colorize'
after 447 ms
```
I'm using runner with this change for several months already. Tested in almost all Bash versions 4.x and 5.x. Didn't experience any side-effects or malfunction. It would be nice to have it also in upstream.

Thanks for considering this PR to merge.